### PR TITLE
fix: create configs/ dir when not present

### DIFF
--- a/project/mods/TackleBox/main.gd
+++ b/project/mods/TackleBox/main.gd
@@ -109,6 +109,9 @@ func _get_gdweave_dir() -> String:
 
 
 func _init_mod_manifests() -> void:
+	if not _dir.dir_exists(mods_directory):
+		_dir.make_dir(mods_directory)
+
 	if _dir.open(mods_directory) != OK:
 		push_error("TackleBox could not open mods directory")
 		return

--- a/project/mods/TackleBox/main.gd
+++ b/project/mods/TackleBox/main.gd
@@ -154,6 +154,9 @@ func _init_mod_manifests() -> void:
 
 
 func _init_mod_configs() -> void:
+	if not _dir.dir_exists(configs_directory):
+		_dir.make_dir(configs_directory)
+	
 	if _dir.open(configs_directory) != OK:
 		push_warning("TackleBox could not open configs directory")
 		return


### PR DESCRIPTION
When the `configs` folder doesn't exist at all, TackleBox will not allow configuring mods by creating a new config file.

Allows mods to rely entirely on Tacklebox for setting up mod files by creating this dir when it is missing.

https://github.com/elliotcubit/WebfishingButtplug/issues/5